### PR TITLE
Type confusion bugfix

### DIFF
--- a/src/Markdown.php
+++ b/src/Markdown.php
@@ -40,8 +40,11 @@ class Markdown extends Parsedown {
 
     public function blockDropCapContinue($line, $Block)
     {
-        if (!isset($Block['interrupted'])) {
-            $Block['element']['text'][1]['text'][] = $line['text'];
+        if (preg_match('/^\^(\w)/', $line['text'], $matches)) {
+            return null;
+        }
+        elseif (!isset($Block['interrupted'])) {
+            $Block['element']['text'][1]['text'] .= "\n".$line['text'];
             return $Block;
         }
     }


### PR DESCRIPTION
Not entirely sure why the PHP interpreter let me get away with this when I wrote it. Nethertheless I used this code to test https://github.com/erusev/parsedown/pull/511 and it didn't work, so here we are.